### PR TITLE
Update update-website.yml

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -24,10 +24,9 @@ jobs:
       - name: Setup R
         uses: r-lib/actions/setup-r@v1
 
-      - name: Install pandoc and pandoc citeproc
+      - name: Install pandoc
         run: |
           brew install pandoc
-          brew install pandoc-citeproc
     
       - name: Install R packages
         run: |


### PR DESCRIPTION
pandoc-citeproc is deprecated and no longer needed (I think).  See https://github.com/r-lib/actions/issues/220