### PR TITLE
Fix for changing urls

### DIFF
--- a/scripts/get_and_clean_data.R
+++ b/scripts/get_and_clean_data.R
@@ -52,7 +52,11 @@ if (is_allowed) {
 
 # get data ---------------------------------------------------------------------
 pathway_calls <- URLencode("NHS Pathways Covid-19 data 20")
-pathway_calls <- grep(pathway_calls, scraped_links, fixed=T, value = TRUE)
+pathway_calls <- grep(pathway_calls, scraped_links, fixed = TRUE, value = TRUE)
+if (length(pathway_calls) == 0L) {
+    pathway_calls <- URLencode("NHS Pathways Covid-19 data_20")
+    pathway_calls <- grep(pathway_calls, scraped_links, fixed = TRUE, value = TRUE)
+}
 pathways_calls_data <- read.csv(
     url(pathway_calls),
     na.strings = c("NA", ""),


### PR DESCRIPTION
The pathways data seems to be uploaded with one of two different filenames
differing only by an underscore. This can be confirmed by looking at the
wayback machine snapshots for the page. This issue also arose in the past when
we were not actively monitoring the pipeline so was not picked up on. This
commit ensures we check for both possible variations.