### PR TITLE
Gini coefficients

### DIFF
--- a/analyses-ccg.Rmd
+++ b/analyses-ccg.Rmd
@@ -5,7 +5,11 @@ description: |
 author:
   - name: Thibaut Jombart, David Simons, Dirk Schumacher, Tim Taylor
 date: "`r Sys.Date() - 1`"
-output: distill::distill_article
+output: 
+  distill::distill_article:
+    toc: true
+    toc_depth: 3
+    toc_float: true
 ---
 
 ```{r setup, include=FALSE}
@@ -51,6 +55,7 @@ library(i2extras)
 library(leaflet)
 library(leafpop)
 library(spdep)
+library(DescTools)
 ```
 
 ```{r prep}
@@ -413,9 +418,38 @@ leaflet(CCG,
             group = "Growth rate") %>%
   addLayersControl(
     baseGroups = c("Outliers", "Growth rate", "Spatially lagged growth rate"),
-    options = layersControlOptions(collapsed = FALSE)
+    options = layersControlOptions(collapsed = FALSE),
+    position = "bottomright"
   )
 ```
+
+### Heterogeneity of reported cases at CCG level
+
+The following graph reports the daily heterogeneity among CCGs measured as the [GINI coefficient](https://www.statsdirect.com/help/default.htm#nonparametric_methods/gini.htm). Values closer to 1 indicate inequality among the distribution of cases across CCGs. The error bars represent bootstrapped 95% confidence intervals.
+
+```{r}
+ccg_by_date <- counts_ccg_all %>%
+  select(date_index, ccg_name, count) %>%
+  split(f = as.factor(.$date_index)) # Data from same time period used in the ASMODEE is split by day
+
+GINI <- list()
+for(i in 1:length(ccg_by_date)) {
+  GINI[[i]] <- Gini(ccg_by_date[[i]]$count, conf.level = 0.95, R = 1000)
+} # A for loop is performed on these list objects to return a GINI coefficient with bootstrapped confidence intervals
+names(GINI) <- names(ccg_by_date) # the date is appended as a name
+
+bind_rows(GINI, .id = "type") %>%
+  mutate(date = as.Date(type)) %>%
+  ggplot(aes(x = date, y = gini)) +
+  geom_point() +
+  geom_pointrange(aes(ymin = lwr.ci, ymax = upr.ci)) +
+  geom_smooth(aes(x = date, y = gini, ymin = lwr.ci, ymax = upr.ci)) +
+  theme_minimal() +
+  labs(x = NULL,
+       y = "GINI Coefficient",
+       title = "Daily heterogeneity in reported cases")
+```
+
 
 ### CCG by numbers of outliers
 

--- a/analyses-ccg.Rmd
+++ b/analyses-ccg.Rmd
@@ -348,6 +348,8 @@ decreases by approximately 2% every day. See this excellent
 [article](https://plus.maths.org/content/epidemic-growth-rate) for more
 information on *r* and its relationship with the reproduction number, *R*.
 
+A spatially lagged growth rate is produced from a direct neighbour spatial weights matrix based on shared land borders between CCGs. 
+
 ``` {r combined, results="markup"}
 CCG <- select(CCG, -ccg)
 plots <- CCG$plots


### PR DESCRIPTION
I've added a TOC as the page is getting a bit long. 

I tried to use `lapply()` but failed miserably so GINI is currently calculated as a rather slow for loop. It uses a new package DescTools but couldn't see how to install a new package so perhaps you can do that when you get a moment.

Left Tim off for review as think he may be on holiday